### PR TITLE
docs: fix typo in readme

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -7,8 +7,8 @@ A list of neat projects made in Ukraine
 
 #### Params
 
-- **Number** `a`: Param descrpition.
-- **Number** `b`: Param descrpition.
+- **Number** `a`: Param description.
+- **Number** `b`: Param description.
 
 #### Return
 - **Number** Return description.


### PR DESCRIPTION
Hi! this is a fix of a typoe in readme `description` for `descrpition`